### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,6 +11,8 @@ jobs:
   validation:
     name: Validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout latest code
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/OMGSoundboard/android-app/security/code-scanning/11](https://github.com/OMGSoundboard/android-app/security/code-scanning/11)

In general, to fix this kind of issue you explicitly define a `permissions` block at the workflow or job level, restricting the `GITHUB_TOKEN` to the minimum needed. For a validation-only workflow that just checks the Gradle wrapper, read-only access to repository contents is sufficient.

The best fix here is to add a `permissions` block at the job level (under `validation:`) with `contents: read`. This avoids altering other workflows and keeps permissions scoped to this job. Concretely, in `.github/workflows/gradle-wrapper-validation.yml`, you should insert:

```yaml
permissions:
  contents: read
```

indented under the `validation` job, between `runs-on: ubuntu-latest` and `steps:` (or just above `runs-on`, as long as YAML structure is correct). No imports or additional definitions are needed; this is standard GitHub Actions syntax and does not change existing functionality, since the job only reads the code and does not write to the repo.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
