### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 9 * * 4'
 
+permissions:
+  contents: read
+
 jobs:
   analyse:
     name: Analyse


### PR DESCRIPTION
Potential fix for [https://github.com/OMGSoundboard/android-app/security/code-scanning/12](https://github.com/OMGSoundboard/android-app/security/code-scanning/12)

Add an explicit `permissions` block to `.github/workflows/codeql-analysis.yml` at the workflow root (recommended here since there is only one job). Start with least privilege:

- `contents: read`

This preserves functionality for checkout and typical CodeQL analysis while removing reliance on mutable repository/org defaults. If your specific CodeQL configuration later requires extra scopes, add only the minimal additional ones.

Change location:

- File: `.github/workflows/codeql-analysis.yml`
- Insert `permissions:` block between the `on:` section and `jobs:`.

No imports, methods, or external dependencies are needed (YAML workflow edit only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
