### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/core/src/main/java/audio/omgsoundboard/core/data/StorageRepositoryImpl.kt
+++ b/core/src/main/java/audio/omgsoundboard/core/data/StorageRepositoryImpl.kt
@@ -87,7 +87,7 @@ class StorageRepositoryImpl @Inject constructor(
                             val normalizedPath = extractedFile.toPath().normalize()
                             val targetDirPath = privateFolder.toPath().normalize()
                             if (!normalizedPath.startsWith(targetDirPath)) {
-                                throw Exception("Bad zip entry: ${entry.name}")
+                                throw IllegalArgumentException("Bad zip entry: ${entry.name}")
                             }
                             FileOutputStream(extractedFile).use { output ->
                                 zipIn.copyTo(output)

--- a/core/src/main/java/audio/omgsoundboard/core/data/StorageRepositoryImpl.kt
+++ b/core/src/main/java/audio/omgsoundboard/core/data/StorageRepositoryImpl.kt
@@ -84,6 +84,11 @@ class StorageRepositoryImpl @Inject constructor(
 
                         entry.name.endsWith(".mp3") -> {
                             val extractedFile = File(privateFolder, entry.name)
+                            val normalizedPath = extractedFile.toPath().normalize()
+                            val targetDirPath = privateFolder.toPath().normalize()
+                            if (!normalizedPath.startsWith(targetDirPath)) {
+                                throw Exception("Bad zip entry: ${entry.name}")
+                            }
                             FileOutputStream(extractedFile).use { output ->
                                 zipIn.copyTo(output)
                             }


### PR DESCRIPTION
Potential fix for [https://github.com/OMGSoundboard/android-app/security/code-scanning/1](https://github.com/OMGSoundboard/android-app/security/code-scanning/1)

To fix the "Zip Slip" vulnerability, we must ensure that files extracted from the zip archive are only written inside the intended destination directory (`privateFolder`). This is done by constructing the output file path, normalizing it, and verifying that it starts with the destination directory's normalized path. If the check fails, we should skip extraction of that entry or throw an exception.

Specifically, in `restoreBackup`, before creating `extractedFile` and writing to it, we should:
- Construct the output path using `File(privateFolder, entry.name)`.
- Normalize the path using `toPath().normalize()`.
- Check that the normalized path starts with `privateFolder.toPath()`.
- Only proceed with extraction if the check passes; otherwise, skip or throw.

This change should be made in the block handling `.mp3` files (lines 85–101). No new methods are needed, but we should import `java.nio.file.Path` if not already available (in Kotlin, `java.io.File.toPath()` is available).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
